### PR TITLE
Fix/simplify script paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "scripts": {
     "start": "name=kubernetes-metrics-proxy node server.js",
     "test": "KUBERNETES_SERVICE_HOST=localhost KUBERNETES_SERVICE_PORT=58443 K8S_BUILD_NAMESPACE=project1 TOKEN_FILE=./token K8S_CACERT=./cacert nyc --reporter=text mocha test --recursive --timeout 25000",
-    "coverage": "nyc ",
-    "posttest": "gulp build",
-    "build": "echo \"Build Success\"",
+    "build": "gulp build",
     "lint": "eslint --fix --ignore-path .gitignore --ext .js,.snap ."
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "server.js",
   "scripts": {
     "start": "name=kubernetes-metrics-proxy node server.js",
-    "test": "KUBERNETES_SERVICE_HOST=localhost KUBERNETES_SERVICE_PORT=58443 K8S_BUILD_NAMESPACE=project1 TOKEN_FILE=./token K8S_CACERT=./cacert node_modules/.bin/nyc --reporter=text node_modules/.bin/mocha test --recursive --timeout 25000",
+    "test": "KUBERNETES_SERVICE_HOST=localhost KUBERNETES_SERVICE_PORT=58443 K8S_BUILD_NAMESPACE=project1 TOKEN_FILE=./token K8S_CACERT=./cacert nyc --reporter=text mocha test --recursive --timeout 25000",
     "coverage": "nyc ",
-    "posttest": "./node_modules/.bin/gulp build",
+    "posttest": "gulp build",
     "build": "echo \"Build Success\"",
     "lint": "eslint --fix --ignore-path .gitignore --ext .js,.snap ."
   },


### PR DESCRIPTION
> If you depend on modules that define executable scripts, like test suites, then those executables will be added to the `PATH` for executing the scripts. 

https://docs.npmjs.com/cli/v8/using-npm/scripts#path